### PR TITLE
调整变 jqxy-"ü" 为 "u" 的次序

### DIFF
--- a/shupin_cendu.schema.yaml
+++ b/shupin_cendu.schema.yaml
@@ -177,6 +177,7 @@ translator:
     - 'xform i[<,] î'
     - 'xform i[>\\] ì'
     - 'xform iq ǐ'
+    - xform/([jqxy])v/$1u/ # jqxy 后的 ü 变 u 需要在给 u 标声调之前
     - 'xform u[-;] ū'
     - 'xform u/ ú'
     - 'xform u[<,] û'
@@ -190,7 +191,6 @@ translator:
     - 'xform v ü'
     - xform/([nl])v/$1ü/
     - xform/([nl])ue/$1üe/
-    - xform/([jqxy])v/$1u/
   comment_format:
     #針對成都音系
     - xform/Ddi/le/ #的字讀音

--- a/shupin_cendu_9key.schema.yaml
+++ b/shupin_cendu_9key.schema.yaml
@@ -177,6 +177,7 @@ translator:
     - 'xform i[<,] î'
     - 'xform i[>\\] ì'
     - 'xform iq ǐ'
+    - xform/([jqxy])v/$1u/ # jqxy 后的 ü 变 u 需要在给 u 标声调之前
     - 'xform u[-;] ū'
     - 'xform u/ ú'
     - 'xform u[<,] û'
@@ -190,7 +191,6 @@ translator:
     - 'xform v ü'
     - xform/([nl])v/$1ü/
     - xform/([nl])ue/$1üe/
-    - xform/([jqxy])v/$1u/
     - xlit/1234567890/໑໒໓໔໕໖໗໘໙໐/
   comment_format:
     #針對成都音系

--- a/shupin_congqin.schema.yaml
+++ b/shupin_congqin.schema.yaml
@@ -174,6 +174,7 @@ translator:
     - 'xform i[<,] î'
     - 'xform i[>\\] ì'
     - 'xform iq ǐ'
+    - xform/([jqxy])v/$1u/ # jqxy 后的 ü 变 u 需要在给 u 标声调之前
     - 'xform u[-;] ū'
     - 'xform u/ ú'
     - 'xform u[<,] û'
@@ -187,7 +188,6 @@ translator:
     - 'xform v ü'
     - xform/([nl])v/$1ü/
     - xform/([nl])ue/$1üe/
-    - xform/([jqxy])v/$1u/
   comment_format:
     #針對重慶音系
     - xform/Ddi/le/ #的字讀音

--- a/shupin_guiyang.schema.yaml
+++ b/shupin_guiyang.schema.yaml
@@ -174,6 +174,7 @@ translator:
     - 'xform i[<,] î'
     - 'xform i[>\\] ì'
     - 'xform iq ǐ'
+    - xform/([jqxy])v/$1u/ # jqxy 后的 ü 变 u 需要在给 u 标声调之前
     - 'xform u[-;] ū'
     - 'xform u/ ú'
     - 'xform u[<,] û'
@@ -187,7 +188,6 @@ translator:
     - 'xform v ü'
     - xform/([nl])v/$1ü/
     - xform/([nl])ue/$1üe/
-    - xform/([jqxy])v/$1u/
   comment_format:
     #針對貴陽音系
     - xform/Ddi/le/ #的字讀音

--- a/shupin_libin.schema.yaml
+++ b/shupin_libin.schema.yaml
@@ -177,6 +177,7 @@ translator:
     - 'xform i[<,] î'
     - 'xform i[>\\] ì'
     - 'xform iq ǐ'
+    - xform/([jqxy])v/$1u/ # jqxy 后的 ü 变 u 需要在给 u 标声调之前
     - 'xform u[-;] ū'
     - 'xform u/ ú'
     - 'xform u[<,] û'
@@ -190,7 +191,6 @@ translator:
     - 'xform v ü'
     - xform/([nl])v/$1ü/
     - xform/([nl])ue/$1üe/
-    - xform/([jqxy])v/$1u/
   comment_format:
     #宜賓音系
     - xform/([dtlzcs])un/$1en/  #啓用此行表示dtlzcs+un都併入en

--- a/shupin_tongyin.schema.yaml
+++ b/shupin_tongyin.schema.yaml
@@ -172,6 +172,7 @@ translator:
     - 'xform i[<,] î'
     - 'xform i[>\\] ì'
     - 'xform iq ǐ'
+    - xform/([jqxy])v/$1u/ # jqxy 后的 ü 变 u 需要在给 u 标声调之前
     - 'xform u[-;] ū'
     - 'xform u/ ú'
     - 'xform u[<,] û'
@@ -185,7 +186,6 @@ translator:
     - 'xform v ü'
     - xform/([nl])v/$1ü/
     - xform/([nl])ue/$1üe/
-    - xform/([jqxy])v/$1u/
   comment_format:
     - xform/^(.*)$/〔$1〕
     - xform 了 liào

--- a/shupin_zigong.schema.yaml
+++ b/shupin_zigong.schema.yaml
@@ -172,6 +172,7 @@ translator:
     - 'xform i[<,] î'
     - 'xform i[>\\] ì'
     - 'xform iq ǐ'
+    - xform/([jqxy])v/$1u/ # jqxy 后的 ü 变 u 需要在给 u 标声调之前
     - 'xform u[-;] ū'
     - 'xform u/ ú'
     - 'xform u[<,] û'
@@ -185,7 +186,6 @@ translator:
     - 'xform v ü'
     - xform/([nl])v/$1ü/
     - xform/([nl])ue/$1üe/
-    - xform/([jqxy])v/$1u/
   comment_format:
     #仁富音系
     - xform/Ddi/le/ #的字讀音


### PR DESCRIPTION
应该在给 "u" 标声调之前，将 jqxy 后的 "ü" 变为 "u"。

否则音节 [jqxy]u 会显示为 [jqxy]ü。如果仅调整到给 "v/ü" 标声调之前（给 "u" 标声调之后），[jqxy]u 的声调不会正确标注（因为给 "u" 标声调的语句已经过了）。
