### PR TITLE
[jqxy]uu 的声调标在后面

### DIFF
--- a/shupin_congqin.schema.yaml
+++ b/shupin_congqin.schema.yaml
@@ -153,7 +153,8 @@ translator:
     - 'xform io[<,] iô'
     - 'xform io[>\\] iò'
     - 'xform ioq iǒ'
-    - xform (u?|v?|i?)(eo|ui|iu|a|i|u|e|o|v)(i?|o?|u?|n?|ng?|r?)([-;/<,>\\q]) $1$2$4$3
+    - xform (u?|v?|i?)(eo|ui|iu|a|i|u|e|o)(i?|o?|u?|n?|ng?|r?)([-;/<,>\\q]) $1$2$4$3
+    - xform (v)(n)([-;/<,>\\q]) $1$3$2
     - 'xform a[-;] ā'
     - 'xform a/ á'
     - 'xform a[<,] â'

--- a/shupin_guiyang.schema.yaml
+++ b/shupin_guiyang.schema.yaml
@@ -153,7 +153,8 @@ translator:
     - 'xform io[<,] iô'
     - 'xform io[>\\] iò'
     - 'xform ioq iǒ'
-    - xform (u?|v?|i?)(eo|ui|iu|a|i|u|e|o|v)(i?|o?|u?|n?|ng?|r?)([-;/<,>\\q]) $1$2$4$3
+    - xform (u?|v?|i?)(eo|ui|iu|a|i|u|e|o)(i?|o?|u?|n?|ng?|r?)([-;/<,>\\q]) $1$2$4$3
+    - xform (v)(n)([-;/<,>\\q]) $1$3$2
     - 'xform a[-;] ā'
     - 'xform a/ á'
     - 'xform a[<,] â'


### PR DESCRIPTION
蜀拼基于汉语拼音，其声调的标记最好也遵循汉语拼音的规则，即：声调标注在主要元音上。在 [jqxy]uu 中，韵母为 "üu", 其中 "u" 是主要元音，"ü" 更像是一个介音。

知乎文章 (https://zhuanlan.zhihu.com/p/79034026) 对于这些音节的声调标注也是标在后面：

juû　橘足
quû　屈族
xuû　续俗
yuû　域疫

由于这类发音只有重庆和贵阳有，仅对于这两个文件改动，若为了规则的一致性，也可对所有方案进行改动。