### PR TITLE
去除反查中无用的特字读音

### DIFF
--- a/shupin_cendu.schema.yaml
+++ b/shupin_cendu.schema.yaml
@@ -342,6 +342,7 @@ reverse_lookup:
     - xform ü5 ǚ
     - xform/([a-z]+)/$1/
     - xform/(◎.+)〕/〕$1/
+    - xform/[A-Z].+[\ $]//
   
 punctuator:
   import_preset: default

--- a/shupin_cendu_9key.schema.yaml
+++ b/shupin_cendu_9key.schema.yaml
@@ -343,6 +343,7 @@ reverse_lookup:
     - xform ü5 ǚ
     - xform/([a-z]+)/$1/
     - xform/(◎.+)〕/〕$1/
+    - xform/[A-Z].+[\ $]//
   
 punctuator:
   import_preset: default

--- a/shupin_congqin.schema.yaml
+++ b/shupin_congqin.schema.yaml
@@ -334,6 +334,7 @@ reverse_lookup:
     - xform ü5 ǚ
     - xform/([a-z]+)/$1/
     - xform/(◎.+)〕/〕$1/
+    - xform/[A-Z].+[\ $]//
   
 punctuator:
   import_preset: default

--- a/shupin_guiyang.schema.yaml
+++ b/shupin_guiyang.schema.yaml
@@ -334,6 +334,7 @@ reverse_lookup:
     - xform ü5 ǚ
     - xform/([a-z]+)/$1/
     - xform/(◎.+)〕/〕$1/
+    - xform/[A-Z].+[\ $]//
   
 punctuator:
   import_preset: default

--- a/shupin_libin.schema.yaml
+++ b/shupin_libin.schema.yaml
@@ -346,6 +346,7 @@ reverse_lookup:
     - xform ü5 ǚ
     - xform/([a-z]+)/$1/
     - xform/(◎.+)〕/〕$1/
+    - xform/[A-Z].+[\ $]//
   
 punctuator:
   import_preset: default

--- a/shupin_tongyin.schema.yaml
+++ b/shupin_tongyin.schema.yaml
@@ -277,6 +277,7 @@ reverse_lookup:
     - xform ü5 ǚ
     - xform/([a-z]+)/$1/
     - xform/(◎.+)〕/〕$1/
+    - xform/[A-Z].+[\ $]//
   
 punctuator:
   import_preset: default

--- a/shupin_zigong.schema.yaml
+++ b/shupin_zigong.schema.yaml
@@ -295,6 +295,7 @@ reverse_lookup:
     - xform ü5 ǚ
     - xform/([a-z]+)/$1/
     - xform/(◎.+)〕/〕$1/
+    - xform/[A-Z].+[\ $]//
   
 punctuator:
   import_preset: default


### PR DESCRIPTION
反查的时候会显示所有读音，包括失效（未转换）的特字，在 `reverse_lookup` 末尾加一条规则可以将其忽略。