### PR TITLE
修正多音字的反查显示

### DIFF
--- a/shupin_cendu.schema.yaml
+++ b/shupin_cendu.schema.yaml
@@ -282,27 +282,27 @@ reverse_lookup:
     - xform/Dqu4/qie4/  #去字讀音
     - xform/Dlu5/liu2/  #六字讀音
     - xform/([dtlzcs])un/$1en/ #啓用此行表示dtlzcs+un都併入en
-    - xform/^([qx])u5($|(◎.+$))/$1io5$2/ #啓用此行表示通入
-    - xform/^su5($|(◎.+$))/sv5$1/
-    - xform/^sv5($|(◎.+$))/sio5$1/
-    - xform/^zu5($|(◎.+$))/zv5$1/
-    - xform/^zu5($|(◎.+$))/zio5$1/
-    - xform/^yu5($|(◎.+$))/yo5$1/
+    - xform/(^|\ )([qx])u5($|(◎.+$))/$1$2io5$3/ #啓用此行表示通入
+    - xform/(^|\ )su5($|(◎.+$))/$1sv5$2/
+    - xform/(^|\ )sv5($|(◎.+$))/$1sio5$2/
+    - xform/(^|\ )zu5($|(◎.+$))/$1zv5$2/
+    - xform/(^|\ )zu5($|(◎.+$))/$1zio5$2/
+    - xform/(^|\ )yu5($|(◎.+$))/$1yo5$2/
     - xform/eo([1234])$/o$1$2/    #啓用此行表示不分舒聲戈歌
     - xform/eo5/o5/ #啓用此行表示不分入聲戈歌
     - xform/5($|(◎.+$))/2$1/   #啓用此行表示入派陽平
-    - xform/^([zcs])h/$1/   #啓用此行表示無翹舌
+    - xform/(^|\ )([zcs])h/$1$2/   #啓用此行表示無翹舌
     - xform/zyi/ji/    #zyi>ji
     - xform/cyi/qi/    #cyi>qi
     - xform/syi/xi/    #syi>xi
-    - xform/^zi([a-z]+)/ji$1/   #zi->ji-
-    - xform/^ci([a-z]+)/qi$1/   #ci->qi-
-    - xform/^si([a-z]+)/xi$1/   #si->xi-
-    - xform/^zv/ju/ #zü>ju, zü->ju-
-    - xform/^cv/qu/ #cü>qu, cü->qu-
-    - xform/^sv/xu/ #sü>xu, sü->xu-
-    - xform/^sv/xu/ #sü>xu, sü->xu-
-    - xform/^hu([12345])($|(◎.+$))/fu$1$2/ #hu>fu
+    - xform/(^|\ )zi([a-z]+)/$1ji$2/   #zi->ji-
+    - xform/(^|\ )ci([a-z]+)/$1qi$2/   #ci->qi-
+    - xform/(^|\ )si([a-z]+)/$1xi$2/   #si->xi-
+    - xform/(^|\ )zv/$1ju/ #zü>ju, zü->ju-
+    - xform/(^|\ )cv/$1qu/ #cü>qu, cü->qu-
+    - xform/(^|\ )sv/$1xu/ #sü>xu, sü->xu-
+    - xform/(^|\ )sv/$1xu/ #sü>xu, sü->xu-
+    - xform/(^|\ )hu([12345])($|(◎.+$))/$1fu$2$3/ #hu>fu
 
     - xform/^(.*)$/〔$1〕
     - xform ([aeiouv])(ng?|r)([1234q]) $1$3$2

--- a/shupin_cendu_9key.schema.yaml
+++ b/shupin_cendu_9key.schema.yaml
@@ -283,27 +283,27 @@ reverse_lookup:
     - xform/Dqu4/qie4/  #去字讀音
     - xform/Dlu5/liu2/  #六字讀音
     - xform/([dtlzcs])un/$1en/ #啓用此行表示dtlzcs+un都併入en
-    - xform/^([qx])u5($|(◎.+$))/$1io5$2/ #啓用此行表示通入
-    - xform/^su5($|(◎.+$))/sv5$1/
-    - xform/^sv5($|(◎.+$))/sio5$1/
-    - xform/^zu5($|(◎.+$))/zv5$1/
-    - xform/^zu5($|(◎.+$))/zio5$1/
-    - xform/^yu5($|(◎.+$))/yo5$1/
+    - xform/(^|\ )([qx])u5($|(◎.+$))/$1$2io5$3/ #啓用此行表示通入
+    - xform/(^|\ )su5($|(◎.+$))/$1sv5$2/
+    - xform/(^|\ )sv5($|(◎.+$))/$1sio5$2/
+    - xform/(^|\ )zu5($|(◎.+$))/$1zv5$2/
+    - xform/(^|\ )zu5($|(◎.+$))/$1zio5$2/
+    - xform/(^|\ )yu5($|(◎.+$))/$1yo5$2/
     - xform/eo([1234])$/o$1$2/    #啓用此行表示不分舒聲戈歌
     - xform/eo5/o5/ #啓用此行表示不分入聲戈歌
     - xform/5($|(◎.+$))/2$1/   #啓用此行表示入派陽平
-    - xform/^([zcs])h/$1/   #啓用此行表示無翹舌
+    - xform/(^|\ )([zcs])h/$1$2/   #啓用此行表示無翹舌
     - xform/zyi/ji/    #zyi>ji
     - xform/cyi/qi/    #cyi>qi
     - xform/syi/xi/    #syi>xi
-    - xform/^zi([a-z]+)/ji$1/   #zi->ji-
-    - xform/^ci([a-z]+)/qi$1/   #ci->qi-
-    - xform/^si([a-z]+)/xi$1/   #si->xi-
-    - xform/^zv/ju/ #zü>ju, zü->ju-
-    - xform/^cv/qu/ #cü>qu, cü->qu-
-    - xform/^sv/xu/ #sü>xu, sü->xu-
-    - xform/^sv/xu/ #sü>xu, sü->xu-
-    - xform/^hu([12345])($|(◎.+$))/fu$1$2/ #hu>fu
+    - xform/(^|\ )zi([a-z]+)/$1ji$2/   #zi->ji-
+    - xform/(^|\ )ci([a-z]+)/$1qi$2/   #ci->qi-
+    - xform/(^|\ )si([a-z]+)/$1xi$2/   #si->xi-
+    - xform/(^|\ )zv/$1ju/ #zü>ju, zü->ju-
+    - xform/(^|\ )cv/$1qu/ #cü>qu, cü->qu-
+    - xform/(^|\ )sv/$1xu/ #sü>xu, sü->xu-
+    - xform/(^|\ )sv/$1xu/ #sü>xu, sü->xu-
+    - xform/(^|\ )hu([12345])($|(◎.+$))/$1fu$2$3/ #hu>fu
 
     - xform/^(.*)$/〔$1〕
     - xform ([aeiouv])(ng?|r)([1234q]) $1$3$2

--- a/shupin_congqin.schema.yaml
+++ b/shupin_congqin.schema.yaml
@@ -274,28 +274,28 @@ reverse_lookup:
     - xform/Ddi/le/ #的字讀音
     - xform/Dqu4/qie4/  #去字讀音
     - derive/([dtlzcs])un/$1en/ #啓用此行表示dtlzcs+un都併入en
-    - xform/^([jqx])u5($|(◎.+$))/$1uu5$2/  #啓用此行表示通入讀üu
-    - xform/^([zcs])v5($|(◎.+$))/$1vu5$2/  #啓用此行表示通入讀üu
-    - xform/^([zcs])u5($|(◎.+$))/$1vu5$2/  #啓用此行表示通入讀üu
-    - xform/^yu5($|(◎.+$))/yvu5$1/ #啓用此行表示通入讀üu
+    - xform/(^|\ )([jqx])u5($|(◎.+$))/$1$2uu5$3/  #啓用此行表示通入讀üu
+    - xform/(^|\ )([zcs])v5($|(◎.+$))/$1$2vu5$3/  #啓用此行表示通入讀üu
+    - xform/(^|\ )([zcs])u5($|(◎.+$))/$1$2vu5$3/  #啓用此行表示通入讀üu
+    - xform/(^|\ )yu5($|(◎.+$))/$1yvu5$2/ #啓用此行表示通入讀üu
     - xform/eo([1234])$/o$1/    #啓用此行表示不分舒聲戈歌
     - xform/eo5/o5/ #啓用此行表示不分入聲戈歌
     - xform/5($|(◎.+$))/2$1/   #啓用此行表示入派陽平
-    - xform/^ni/li/ #啓用此行表示ni, ni->li, li-
-    - xform/^nv/lv/
-    - xform/^zyi/ji/    #zyi>ji
-    - xform/^cyi/qi/    #cyi>qi
-    - xform/^syi/xi/    #syi>xi
-    - xform/^zi([a-z]+)/ji$1/   #zi->ji-
-    - xform/^ci([a-z]+)/qi$1/   #ci->qi-
-    - xform/^si([a-z]+)/xi$1/   #si->xi-
-    - xform/^zv/ju/ #zü>ju, zü->ju-
-    - xform/^cv/qu/ #cü>qu, cü->qu-
-    - xform/^sv/xu/ #sü>xu, sü->xu-
-    - xform/^sv/xu/ #sü>xu, sü->xu-
-    - xform/^yv/yu/
-    - xform/^([zcs])h/$1/   #啓用此行表示無翹舌
-    - xform/^hu([12345])$/fu$1/ #hu>fu
+    - xform/(^|\ )ni/$1li/ #啓用此行表示ni, ni->li, li-
+    - xform/(^|\ )nv/$1lv/
+    - xform/(^|\ )zyi/$1ji/    #zyi>ji
+    - xform/(^|\ )cyi/$1qi/    #cyi>qi
+    - xform/(^|\ )syi/$1xi/    #syi>xi
+    - xform/(^|\ )zi([a-z]+)/$1ji$2/   #zi->ji-
+    - xform/(^|\ )ci([a-z]+)/$1qi$2/   #ci->qi-
+    - xform/(^|\ )si([a-z]+)/$1xi$2/   #si->xi-
+    - xform/(^|\ )zv/$1ju/ #zü>ju, zü->ju-
+    - xform/(^|\ )cv/$1qu/ #cü>qu, cü->qu-
+    - xform/(^|\ )sv/$1xu/ #sü>xu, sü->xu-
+    - xform/(^|\ )sv/$1xu/ #sü>xu, sü->xu-
+    - xform/(^|\ )yv/$1yu/
+    - xform/(^|\ )([zcs])h/$1$2/   #啓用此行表示無翹舌
+    - xform/(^|\ )hu([12345])$/$1fu$2/ #hu>fu
 
     - xform/^(.*)$/〔$1〕
     - xform ([aeiouv])(ng?|r)([1234q]) $1$3$2

--- a/shupin_guiyang.schema.yaml
+++ b/shupin_guiyang.schema.yaml
@@ -274,28 +274,28 @@ reverse_lookup:
     - xform/Ddi/le/ #的字讀音
     - xform/Dqu4/qie4/  #去字讀音
     - derive/([dtlzcs])un/$1en/ #啓用此行表示dtlzcs+un都併入en
-    - xform/^([jqx])u5($|(◎.+$))/$1uu5$2/  #啓用此行表示通入讀üu
-    - xform/^([zcs])v5($|(◎.+$))/$1vu5$2/  #啓用此行表示通入讀üu
-    - xform/^([zcs])u5($|(◎.+$))/$1vu5$2/  #啓用此行表示通入讀üu
-    - xform/^yu5($|(◎.+$))/yvu5$1/ #啓用此行表示通入讀üu
+    - xform/(^|\ )([jqx])u5($|(◎.+$))/$1$2uu5$3/  #啓用此行表示通入讀üu
+    - xform/(^|\ )([zcs])v5($|(◎.+$))/$1$2vu5$3/  #啓用此行表示通入讀üu
+    - xform/(^|\ )([zcs])u5($|(◎.+$))/$1$2vu5$3/  #啓用此行表示通入讀üu
+    - xform/(^|\ )yu5($|(◎.+$))/$1yvu5$2/ #啓用此行表示通入讀üu
     - xform/eo([1234])$/o$1/    #啓用此行表示不分舒聲戈歌
     - xform/eo5/o5/ #啓用此行表示不分入聲戈歌
     - xform/5($|(◎.+$))/2$1/   #啓用此行表示入派陽平
-    - xform/^ni/li/ #啓用此行表示ni, ni->li, li-
-    - xform/^nv/lv/
-    - xform/^zyi/ji/    #zyi>ji
-    - xform/^cyi/qi/    #cyi>qi
-    - xform/^syi/xi/    #syi>xi
-    - xform/^zi([a-z]+)/ji$1/   #zi->ji-
-    - xform/^ci([a-z]+)/qi$1/   #ci->qi-
-    - xform/^si([a-z]+)/xi$1/   #si->xi-
-    - xform/^zv/ju/ #zü>ju, zü->ju-
-    - xform/^cv/qu/ #cü>qu, cü->qu-
-    - xform/^sv/xu/ #sü>xu, sü->xu-
-    - xform/^sv/xu/ #sü>xu, sü->xu-
-    - xform/^yv/yu/
-    - xform/^([zcs])h/$1/   #啓用此行表示無翹舌
-    - xform/^hu([12345])$/fu$1/ #hu>fu
+    - xform/(^|\ )ni/$1li/ #啓用此行表示ni, ni->li, li-
+    - xform/(^|\ )nv/$1lv/
+    - xform/(^|\ )zyi/$1ji/    #zyi>ji
+    - xform/(^|\ )cyi/$1qi/    #cyi>qi
+    - xform/(^|\ )syi/$1xi/    #syi>xi
+    - xform/(^|\ )zi([a-z]+)/$1ji$2/   #zi->ji-
+    - xform/(^|\ )ci([a-z]+)/$1qi$2/   #ci->qi-
+    - xform/(^|\ )si([a-z]+)/$1xi$2/   #si->xi-
+    - xform/(^|\ )zv/$1ju/ #zü>ju, zü->ju-
+    - xform/(^|\ )cv/$1qu/ #cü>qu, cü->qu-
+    - xform/(^|\ )sv/$1xu/ #sü>xu, sü->xu-
+    - xform/(^|\ )sv/$1xu/ #sü>xu, sü->xu-
+    - xform/(^|\ )yv/$1yu/
+    - xform/(^|\ )([zcs])h/$1$2/   #啓用此行表示無翹舌
+    - xform/(^|\ )hu([12345])$/$1fu$2/ #hu>fu
 
     - xform/^(.*)$/〔$1〕
     - xform ([aeiouv])(ng?|r)([1234q]) $1$3$2

--- a/shupin_libin.schema.yaml
+++ b/shupin_libin.schema.yaml
@@ -281,33 +281,33 @@ reverse_lookup:
     - xform/([dtlzcs])un/$1en/  #啓用此行表示dtlzcs+un都併入en
     - xform/Ddi/le/ #的字讀音
     - xform/Dqu4/jie5/  #去字讀音
-    - xform/^([jqx])u5$/$1io5/  #啓用此行表示通入讀io
-    - xform/^([zcs])v5$/$1io5/  #啓用此行表示通入讀io
-    - xform/^([zcs])u5$/$1io5/  #啓用此行表示通入讀io
-    - xform/^yu5$/yo5/  #啓用此行表示通入讀io
+    - xform/(^|\ )([jqx])u5$/$1$2io5/  #啓用此行表示通入讀io
+    - xform/(^|\ )([zcs])v5$/$1$2io5/  #啓用此行表示通入讀io
+    - xform/(^|\ )([zcs])u5$/$1$2io5/  #啓用此行表示通入讀io
+    - xform/(^|\ )yu5$/$1yo5/  #啓用此行表示通入讀io
     - xform/eo([1234])$/o$1/  #啓用此行表示不分舒聲戈歌
     - xform/eo5/o5/ #啓用此行表示不分入聲戈歌
     - xform/i5/ie5/ #啓用此行表示iq>ieq，注意和上行區分
     - xform/yie5/ye5/
     - xform/ue5/o5/ #啓用此行表示ueq>oq
     - xform/u5/o5/  #啓用此行表示uq>oq
-    - xform/^ni/li/ #啓用此行表示ni, ni->li, li-
-    - xform/^nv/lv/
-    - xform/^zyi/ji/  #zyi>ji
-    - xform/^cyi/qi/  #cyi>qi
-    - xform/^syi/xi/  #syi>xi
-    - xform/^zi([a-z]+)/ji$1/ #zi->ji-
-    - xform/^ci([a-z]+)/qi$1/ #ci->qi-
-    - xform/^si([a-z]+)/xi$1/ #si->xi-
-    - xform/^zv/ju/ #zü>ju, zü->ju-
-    - xform/^cv/qu/ #cü>qu, cü->qu-
-    - xform/^sv/xu/ #sü>xu, sü->xu-
-    - xform/^sv/xu/ #sü>xu, sü->xu-
-    - xform/^([zcs])h/$1/  #啓用此行表示無翹舌
-    - xform/^hu([12345])$/fu$1/ #hu>fu
+    - xform/(^|\ )ni/$1li/ #啓用此行表示ni, ni->li, li-
+    - xform/(^|\ )nv/$1lv/
+    - xform/(^|\ )zyi/$1ji/  #zyi>ji
+    - xform/(^|\ )cyi/$1qi/  #cyi>qi
+    - xform/(^|\ )syi/$1xi/  #syi>xi
+    - xform/(^|\ )zi([a-z]+)/$1ji$2/ #zi->ji-
+    - xform/(^|\ )ci([a-z]+)/$1qi$2/ #ci->qi-
+    - xform/(^|\ )si([a-z]+)/$1xi$2/ #si->xi-
+    - xform/(^|\ )zv/$1ju/ #zü>ju, zü->ju-
+    - xform/(^|\ )cv/$1qu/ #cü>qu, cü->qu-
+    - xform/(^|\ )sv/$1xu/ #sü>xu, sü->xu-
+    - xform/(^|\ )sv/$1xu/ #sü>xu, sü->xu-
+    - xform/(^|\ )([zcs])h/$1$2/  #啓用此行表示無翹舌
+    - xform/(^|\ )hu([12345])$/$1fu$2/ #hu>fu
     - xform/ie([1234])$/i$1/
     - xform/ye([1234])$/yi$1/
-    - xform/^([zcsr])e([1234])$/$1ei$2/
+    - xform/(^|\ )([zcsr])e([1234])$/$1$2ei$3/
 
     - xform/^(.*)$/〔$1〕
     - xform ([aeiouv])(ng?|r)([1234q]) $1$3$2


### PR DESCRIPTION
多音字的读音在反查时可能不在开头，而是在空格后面，这会造成第二个及以后的读音无法作出某些变形